### PR TITLE
Serve frontend from backend

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ INSTRUCCIONES:
 2. Ejecutá:
    npm install
    PORT=3000 DB_PATH=./db.sqlite node server.js
-3. Abrí 'frontend/login.html' con Live Server.
+3. Abrí http://localhost:3000/ en el navegador.
 4. Usá login o registro. Solo los usuarios logueados pueden agregar al carrito.
 
 La base de datos se encuentra en: backend/db.sqlite

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 
 const express = require('express');
 const cors = require('cors');
+const path = require('path');
 const authRoutes = require('./routes/auth');
 const confirmRoutes = require('./routes/confirm');
 const productRoutes = require('./routes/products');
@@ -9,6 +10,10 @@ const cartRoutes = require('./routes/cart');
 const app = express();
 app.use(cors());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '../frontend')));
+app.get('/', (req, res) =>
+  res.sendFile(path.join(__dirname, '../frontend/landing.html'))
+);
 
 app.use('/api', authRoutes);
 app.use('/api', productRoutes);


### PR DESCRIPTION
## Summary
- serve static files from `frontend` in `server.js`
- set landing page handler and import `path`
- update README to visit the backend URL

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `PORT=3000 DB_PATH=./db.sqlite node server.js` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_6855e9347124832e8ed1c6a8944f2ade