### PR TITLE
Fix cart confirmation

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -25,6 +25,16 @@ db.serialize(() => {
     FOREIGN KEY(userId) REFERENCES users(id),
     FOREIGN KEY(productId) REFERENCES products(id)
   )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId INTEGER,
+    productId INTEGER,
+    quantity INTEGER,
+    orderDate TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY(userId) REFERENCES users(id),
+    FOREIGN KEY(productId) REFERENCES products(id)
+  )`);
 });
 
 module.exports = db;

--- a/backend/routes/confirm.js
+++ b/backend/routes/confirm.js
@@ -5,9 +5,19 @@ const router = express.Router();
 
 router.post('/confirm', (req, res) => {
   const { userId } = req.body;
-  db.run('DELETE FROM cart WHERE userId = ?', [userId], function(err) {
-    if (err) return res.status(500).json({ error: err.message });
-    res.json({ message: "Compra confirmada y carrito vaciado." });
+  db.serialize(() => {
+    db.run(
+      `INSERT INTO orders (userId, productId, quantity)
+       SELECT userId, productId, quantity FROM cart WHERE userId = ?`,
+      [userId],
+      function (err) {
+        if (err) return res.status(500).json({ error: err.message });
+        db.run('DELETE FROM cart WHERE userId = ?', [userId], function (delErr) {
+          if (delErr) return res.status(500).json({ error: delErr.message });
+          res.json({ message: 'Compra confirmada.' });
+        });
+      }
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- create orders table
- save cart items into orders on confirmation
- empty cart only after saving

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855ef971f04832ea355a386814c6c89