### PR TITLE
Implement orders table for purchase history

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -25,6 +25,18 @@ db.serialize(() => {
     FOREIGN KEY(userId) REFERENCES users(id),
     FOREIGN KEY(productId) REFERENCES products(id)
   )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId INTEGER,
+    productId INTEGER,
+    productName TEXT,
+    productPrice REAL,
+    quantity INTEGER,
+    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(userId) REFERENCES users(id),
+    FOREIGN KEY(productId) REFERENCES products(id)
+  )`);
 });
 
 module.exports = db;

--- a/backend/routes/confirm.js
+++ b/backend/routes/confirm.js
@@ -5,9 +5,35 @@ const router = express.Router();
 
 router.post('/confirm', (req, res) => {
   const { userId } = req.body;
-  db.run('DELETE FROM cart WHERE userId = ?', [userId], function(err) {
+
+  const q = `
+    SELECT c.productId, c.quantity, p.name, p.price
+    FROM cart c
+    JOIN products p ON c.productId = p.id
+    WHERE c.userId = ?
+  `;
+
+  db.all(q, [userId], (err, items) => {
     if (err) return res.status(500).json({ error: err.message });
-    res.json({ message: "Compra confirmada y carrito vaciado." });
+
+    if (!items.length) {
+      return res.json({ message: "No hay productos en el carrito." });
+    }
+
+    const stmt = db.prepare(
+      'INSERT INTO orders (userId, productId, productName, productPrice, quantity) VALUES (?, ?, ?, ?, ?)'
+    );
+    items.forEach(i => {
+      stmt.run(userId, i.productId, i.name, i.price, i.quantity);
+    });
+    stmt.finalize(err => {
+      if (err) return res.status(500).json({ error: err.message });
+
+      db.run('DELETE FROM cart WHERE userId = ?', [userId], function(err) {
+        if (err) return res.status(500).json({ error: err.message });
+        res.json({ message: "Compra confirmada y registrada." });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- create an `orders` table in the DB initialization
- store items from the cart into `orders` when confirming purchases

## Testing
- `node backend/server.js` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_6855f1967e58832e9f41a84501e7981d