### PR TITLE
Fix landing redirect and logout

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -10,10 +10,12 @@ const cartRoutes = require('./routes/cart');
 const app = express();
 app.use(cors());
 app.use(express.json());
-app.use(express.static(path.join(__dirname, '../frontend')));
+// Sirve la página de inicio antes de la carpeta estática para evitar que index.html
+// intercepte la ruta raíz
 app.get('/', (req, res) =>
   res.sendFile(path.join(__dirname, '../frontend/landing.html'))
 );
+app.use(express.static(path.join(__dirname, '../frontend')));
 
 app.use('/api', authRoutes);
 app.use('/api', productRoutes);

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -6,7 +6,8 @@ function checkSession() {
 
 function logout() {
   localStorage.removeItem("user");
-  window.location.href = "login.html";
+  // Al cerrar sesión volvemos a la página principal
+  window.location.href = "landing.html";
 }
 
 async function register() {


### PR DESCRIPTION
## Summary
- fix Express route order to serve landing page
- redirect logout to landing page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855f9f6385c832e9b58c31ea3b1373f