### PR TITLE
Group purchase items with orderId

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -28,6 +28,7 @@ db.serialize(() => {
 
   db.run(`CREATE TABLE IF NOT EXISTS orders (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    orderId INTEGER,
     userId INTEGER,
     productId INTEGER,
     productName TEXT,
@@ -37,6 +38,15 @@ db.serialize(() => {
     FOREIGN KEY(userId) REFERENCES users(id),
     FOREIGN KEY(productId) REFERENCES products(id)
   )`);
+
+  // Ensure the orderId column exists for databases created with older versions
+  db.all('PRAGMA table_info(orders)', (err, columns) => {
+    if (err) return;
+    const hasOrderId = columns.some(c => c.name === 'orderId');
+    if (!hasOrderId) {
+      db.run('ALTER TABLE orders ADD COLUMN orderId INTEGER');
+    }
+  });
 });
 
 module.exports = db;

--- a/backend/routes/confirm.js
+++ b/backend/routes/confirm.js
@@ -20,18 +20,24 @@ router.post('/confirm', (req, res) => {
       return res.json({ message: "No hay productos en el carrito." });
     }
 
-    const stmt = db.prepare(
-      'INSERT INTO orders (userId, productId, productName, productPrice, quantity) VALUES (?, ?, ?, ?, ?)'
-    );
-    items.forEach(i => {
-      stmt.run(userId, i.productId, i.name, i.price, i.quantity);
-    });
-    stmt.finalize(err => {
-      if (err) return res.status(500).json({ error: err.message });
+    db.get('SELECT COALESCE(MAX(orderId), 0) as maxId FROM orders', (err2, row) => {
+      if (err2) return res.status(500).json({ error: err2.message });
 
-      db.run('DELETE FROM cart WHERE userId = ?', [userId], function(err) {
+      const orderId = (row ? row.maxId : 0) + 1;
+
+      const stmt = db.prepare(
+        'INSERT INTO orders (orderId, userId, productId, productName, productPrice, quantity) VALUES (?, ?, ?, ?, ?, ?)'
+      );
+      items.forEach(i => {
+        stmt.run(orderId, userId, i.productId, i.name, i.price, i.quantity);
+      });
+      stmt.finalize(err => {
         if (err) return res.status(500).json({ error: err.message });
-        res.json({ message: "Compra confirmada y registrada." });
+
+        db.run('DELETE FROM cart WHERE userId = ?', [userId], function(err) {
+          if (err) return res.status(500).json({ error: err.message });
+          res.json({ message: "Compra confirmada y registrada." });
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary
- extend `orders` table with an `orderId` column
- keep schema backward compatible by adding column if missing
- insert cart items using a common `orderId` so one purchase shares the same id

## Testing
- `npm start` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_6855fd26c31c832eb02ea9bf5e5d97f0