### PR TITLE
Fix SQLite UNIQUE column error

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -23,7 +23,10 @@ db.serialize(() => {
       db.run('ALTER TABLE users ADD COLUMN last_name TEXT');
     }
     if (!names.includes('email')) {
-      db.run('ALTER TABLE users ADD COLUMN email TEXT UNIQUE');
+      db.run('ALTER TABLE users ADD COLUMN email TEXT');
+      db.run(
+        'CREATE UNIQUE INDEX IF NOT EXISTS users_email_unique ON users(email)'
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- fix initialization for `email` column by creating index instead of `UNIQUE` column

## Testing
- `npm start` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_68562504062c832eb2c80abb76da21e8