### PR TITLE
Add new products to landing and DB

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -37,6 +37,28 @@ db.serialize(() => {
     price REAL
   )`);
 
+  // Insert default products if they don't exist
+  const defaultProducts = [
+    { name: 'Café Molido', description: '250g café molido premium', price: 3500 },
+    { name: 'Café en Grano', description: 'Café en grano de altura', price: 4000 },
+    { name: 'Café Orgánico', description: 'Café sin pesticidas certificado', price: 4500 },
+    { name: 'Taza de Cerámica', description: 'Taza térmica de alta calidad', price: 2500 },
+    { name: 'Filtro de Papel', description: 'Paquete de 100 filtros para café', price: 500 }
+  ];
+
+  db.all('SELECT name FROM products', (err, rows) => {
+    if (err) return;
+    const names = rows.map(r => r.name);
+    defaultProducts.forEach(p => {
+      if (!names.includes(p.name)) {
+        db.run(
+          'INSERT INTO products (name, description, price) VALUES (?, ?, ?)',
+          [p.name, p.description, p.price]
+        );
+      }
+    });
+  });
+
   db.run(`CREATE TABLE IF NOT EXISTS cart (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     userId INTEGER,

--- a/frontend/landing.html
+++ b/frontend/landing.html
@@ -28,6 +28,21 @@
           <h3>Café Orgánico</h3>
           <p>Café certificado, sin pesticidas.</p>
         </div>
+        <div class="product-card">
+          <img src="assets/product-default.jpg" alt="Producto">
+          <h3>Café en Grano</h3>
+          <p>Café en grano de altura.</p>
+        </div>
+        <div class="product-card">
+          <img src="assets/product-default.jpg" alt="Producto">
+          <h3>Taza de Cerámica</h3>
+          <p>Taza térmica para café.</p>
+        </div>
+        <div class="product-card">
+          <img src="assets/product-default.jpg" alt="Producto">
+          <h3>Filtro de Papel</h3>
+          <p>Paquete de 100 filtros.</p>
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- seed default products with accessories on database init
- showcase additional products on landing page

## Testing
- `npm install --silent` *(fails: network not available)*

------
https://chatgpt.com/codex/tasks/task_e_68562f2fd180832eb051bb9f4c1e54e1