### PR TITLE
Actualiza tabla de usuarios con campos en español

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -6,27 +6,30 @@ const db = new sqlite3.Database(dbPath);
 db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    first_name TEXT,
-    last_name TEXT,
-    email TEXT UNIQUE,
-    password TEXT
+    nombre TEXT,
+    apellido TEXT,
+    correo TEXT UNIQUE,
+    contrasena TEXT
   )`);
 
   // Ensure new columns exist for older databases
   db.all('PRAGMA table_info(users)', (err, columns) => {
     if (err) return;
     const names = columns.map(c => c.name);
-    if (!names.includes('first_name')) {
-      db.run('ALTER TABLE users ADD COLUMN first_name TEXT');
+    if (!names.includes('nombre')) {
+      db.run('ALTER TABLE users ADD COLUMN nombre TEXT');
     }
-    if (!names.includes('last_name')) {
-      db.run('ALTER TABLE users ADD COLUMN last_name TEXT');
+    if (!names.includes('apellido')) {
+      db.run('ALTER TABLE users ADD COLUMN apellido TEXT');
     }
-    if (!names.includes('email')) {
-      db.run('ALTER TABLE users ADD COLUMN email TEXT');
+    if (!names.includes('correo')) {
+      db.run('ALTER TABLE users ADD COLUMN correo TEXT');
       db.run(
-        'CREATE UNIQUE INDEX IF NOT EXISTS users_email_unique ON users(email)'
+        'CREATE UNIQUE INDEX IF NOT EXISTS users_correo_unique ON users(correo)'
       );
+    }
+    if (!names.includes('contrasena')) {
+      db.run('ALTER TABLE users ADD COLUMN contrasena TEXT');
     }
   });
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -5,18 +5,18 @@ const db = require('../models/db');
 const router = express.Router();
 
 router.post('/register', async (req, res) => {
-  const { firstName, lastName, email, password } = req.body;
-  if (!email || !email.includes('@')) {
+  const { nombre, apellido, correo, contrasena } = req.body;
+  if (!correo || !correo.includes('@')) {
     return res.status(400).json({ error: 'Correo electrónico inválido' });
   }
   try {
-    const hash = await bcrypt.hash(password, 10);
+    const hash = await bcrypt.hash(contrasena, 10);
     db.run(
-      'INSERT INTO users (first_name, last_name, email, password) VALUES (?, ?, ?, ?)',
-      [firstName, lastName, email, hash],
+      'INSERT INTO users (nombre, apellido, correo, contrasena) VALUES (?, ?, ?, ?)',
+      [nombre, apellido, correo, hash],
       function (err) {
         if (err) return res.status(500).json({ error: err.message });
-        res.json({ id: this.lastID, email });
+        res.json({ id: this.lastID, correo });
       }
     );
   } catch (err) {
@@ -25,13 +25,13 @@ router.post('/register', async (req, res) => {
 });
 
 router.post('/login', (req, res) => {
-  const { email, password } = req.body;
-  db.get('SELECT * FROM users WHERE email = ?', [email], async (err, row) => {
+  const { correo, contrasena } = req.body;
+  db.get('SELECT * FROM users WHERE correo = ?', [correo], async (err, row) => {
     if (err) return res.status(500).json({ error: err.message });
     if (!row) return res.status(401).json({ error: 'Credenciales inválidas' });
-    const match = await bcrypt.compare(password, row.password);
+    const match = await bcrypt.compare(contrasena, row.contrasena);
     if (!match) return res.status(401).json({ error: 'Credenciales inválidas' });
-    res.json({ id: row.id, email: row.email, firstName: row.first_name, lastName: row.last_name });
+    res.json({ id: row.id, correo: row.correo, nombre: row.nombre, apellido: row.apellido });
   });
 });
 

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -11,31 +11,31 @@ function logout() {
 }
 
 async function register() {
-  const firstName = document.getElementById('regFirstName').value;
-  const lastName = document.getElementById('regLastName').value;
-  const email = document.getElementById('regEmail').value;
-  const password = document.getElementById('regPass').value;
-  if (!email.includes('@')) {
+  const nombre = document.getElementById('regFirstName').value;
+  const apellido = document.getElementById('regLastName').value;
+  const correo = document.getElementById('regEmail').value;
+  const contrasena = document.getElementById('regPass').value;
+  if (!correo.includes('@')) {
     alert('Correo electrónico inválido');
     return;
   }
   const res = await fetch("/api/register", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ firstName, lastName, email, password }),
+    body: JSON.stringify({ nombre, apellido, correo, contrasena }),
   });
   const data = await res.json();
-  alert(data.email ? "Registro exitoso" : data.error);
-  if (data.email) window.location.href = "login.html";
+  alert(data.correo ? "Registro exitoso" : data.error);
+  if (data.correo) window.location.href = "login.html";
 }
 
 async function login() {
-  const email = document.getElementById('logEmail').value;
-  const password = document.getElementById('logPass').value;
+  const correo = document.getElementById('logEmail').value;
+  const contrasena = document.getElementById('logPass').value;
   const res = await fetch("/api/login", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, password }),
+    body: JSON.stringify({ correo, contrasena }),
   });
   const data = await res.json();
   if (res.ok) {


### PR DESCRIPTION
## Summary
- cambia nombres de columnas en la tabla `users` a nombre, apellido, correo y contrasena
- ajusta endpoints de registro y login para usar los nuevos campos
- actualiza la lógica del frontend para enviar y recibir los datos en español

## Testing
- `npm start` *(falla: module not found debido a dependencias no instaladas)*

------
https://chatgpt.com/codex/tasks/task_e_6856320dff28832e9f812827a279dee3