### PR TITLE
Add payment method selection page

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -67,7 +67,11 @@ async function removeFromCart(itemId) {
   viewCart();
 }
 
-async function confirmPurchase() {
+function goToPayment() {
+  window.location.href = "payment.html";
+}
+
+async function confirmPurchase(method) {
   const user = JSON.parse(localStorage.getItem("user"));
   if (!user) return;
 
@@ -78,6 +82,6 @@ async function confirmPurchase() {
   });
 
   const data = await res.json();
-  alert(data.message || "Compra confirmada.");
-  viewCart();
+  alert(`${data.message || "Compra confirmada."}\nMétodo: ${method}`);
+  window.location.href = "index.html";
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,7 +18,7 @@
       <h2>Carrito</h2>
       <div id="cart" class="cart-container"></div>
       <div id="cart-total" class="cart-total"></div>
-      <button onclick="confirmPurchase()">Confirmar Compra</button>
+      <button onclick="goToPayment()">Confirmar Compra</button>
     </main>
     <footer class="footer">
       Café El Mejor &copy; 2025 - Todos los derechos reservados.

--- a/frontend/payment.html
+++ b/frontend/payment.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Método de Pago - Café El Mejor</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="auth-body" onload="checkSession()">
+  <div class="auth-container">
+    <h2>Elige una forma de pago</h2>
+    <button onclick="confirmPurchase('Tarjeta de Débito')">Tarjeta de Débito</button>
+    <button onclick="confirmPurchase('Tarjeta de Crédito')">Tarjeta de Crédito</button>
+    <button onclick="confirmPurchase('Código QR')">Código QR</button>
+  </div>
+  <script src="auth.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- open a separate payment screen from the cart
- add goToPayment helper in JS and send payment method when confirming
- update cart page button to use the payment screen

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685849b8e07c832eaa73b2c95022c408