### PR TITLE
Store chosen payment method

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -79,17 +79,21 @@ db.serialize(() => {
     productName TEXT,
     productPrice REAL,
     quantity INTEGER,
+    paymentMethod TEXT,
     createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY(userId) REFERENCES users(id),
     FOREIGN KEY(productId) REFERENCES products(id)
   )`);
 
-  // Ensure the orderId column exists for databases created with older versions
+  // Ensure new columns exist for databases created with older versions
   db.all('PRAGMA table_info(orders)', (err, columns) => {
     if (err) return;
-    const hasOrderId = columns.some(c => c.name === 'orderId');
-    if (!hasOrderId) {
+    const names = columns.map(c => c.name);
+    if (!names.includes('orderId')) {
       db.run('ALTER TABLE orders ADD COLUMN orderId INTEGER');
+    }
+    if (!names.includes('paymentMethod')) {
+      db.run('ALTER TABLE orders ADD COLUMN paymentMethod TEXT');
     }
   });
 });

--- a/backend/routes/confirm.js
+++ b/backend/routes/confirm.js
@@ -4,7 +4,7 @@ const db = require('../models/db');
 const router = express.Router();
 
 router.post('/confirm', (req, res) => {
-  const { userId } = req.body;
+  const { userId, method } = req.body;
 
   const q = `
     SELECT c.productId, c.quantity, p.name, p.price
@@ -26,10 +26,10 @@ router.post('/confirm', (req, res) => {
       const orderId = (row ? row.maxId : 0) + 1;
 
       const stmt = db.prepare(
-        'INSERT INTO orders (orderId, userId, productId, productName, productPrice, quantity) VALUES (?, ?, ?, ?, ?, ?)'
+        'INSERT INTO orders (orderId, userId, productId, productName, productPrice, quantity, paymentMethod) VALUES (?, ?, ?, ?, ?, ?, ?)'
       );
       items.forEach(i => {
-        stmt.run(orderId, userId, i.productId, i.name, i.price, i.quantity);
+        stmt.run(orderId, userId, i.productId, i.name, i.price, i.quantity, method);
       });
       stmt.finalize(err => {
         if (err) return res.status(500).json({ error: err.message });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -78,7 +78,7 @@ async function confirmPurchase(method) {
   const res = await fetch("/api/confirm", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ userId: user.id }),
+    body: JSON.stringify({ userId: user.id, method }),
   });
 
   const data = await res.json();


### PR DESCRIPTION
## Summary
- add `paymentMethod` column to the `orders` table and migrate old DBs
- store the payment method when confirming an order
- send the method in the front-end request

## Testing
- `npm start` *(fails: Cannot find module 'bcrypt')*
- `node backend/server.js` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_68584f3f1854832ebc7cf9f16f254ea7