### PR TITLE
Renombrar tablas a español

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -4,7 +4,7 @@ const dbPath = process.env.DB_PATH || './db.sqlite';
 const db = new sqlite3.Database(dbPath);
 
 db.serialize(() => {
-  db.run(`CREATE TABLE IF NOT EXISTS users (
+  db.run(`CREATE TABLE IF NOT EXISTS usuarios (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     nombre TEXT,
     apellido TEXT,
@@ -13,96 +13,96 @@ db.serialize(() => {
   )`);
 
   // Ensure new columns exist for older databases
-  db.all('PRAGMA table_info(users)', (err, columns) => {
+  db.all('PRAGMA table_info(usuarios)', (err, columns) => {
     if (err) return;
     const names = columns.map(c => c.name);
     if (!names.includes('nombre')) {
-      db.run('ALTER TABLE users ADD COLUMN nombre TEXT');
+      db.run('ALTER TABLE usuarios ADD COLUMN nombre TEXT');
     }
     if (!names.includes('apellido')) {
-      db.run('ALTER TABLE users ADD COLUMN apellido TEXT');
+      db.run('ALTER TABLE usuarios ADD COLUMN apellido TEXT');
     }
     if (!names.includes('correo')) {
-      db.run('ALTER TABLE users ADD COLUMN correo TEXT');
+      db.run('ALTER TABLE usuarios ADD COLUMN correo TEXT');
       db.run(
-        'CREATE UNIQUE INDEX IF NOT EXISTS users_correo_unique ON users(correo)'
+        'CREATE UNIQUE INDEX IF NOT EXISTS usuarios_correo_unique ON usuarios(correo)'
       );
     }
     if (!names.includes('contrasena')) {
-      db.run('ALTER TABLE users ADD COLUMN contrasena TEXT');
+      db.run('ALTER TABLE usuarios ADD COLUMN contrasena TEXT');
     }
   });
 
-  db.run(`CREATE TABLE IF NOT EXISTS products (
+  db.run(`CREATE TABLE IF NOT EXISTS productos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT,
-    description TEXT,
-    price REAL
+    nombre TEXT,
+    descripcion TEXT,
+    precio REAL
   )`);
 
-  // Insert default products if they don't exist
+  // Insertar productos predeterminados si no existen
   const defaultProducts = [
-    { name: 'Café Molido', description: '250g café molido premium', price: 3500 },
-    { name: 'Café en Grano', description: 'Café en grano de altura', price: 4000 },
-    { name: 'Café Orgánico', description: 'Café sin pesticidas certificado', price: 4500 },
-    { name: 'Taza de Cerámica', description: 'Taza térmica de alta calidad', price: 2500 },
-    { name: 'Filtro de Papel', description: 'Paquete de 100 filtros para café', price: 500 }
+    { nombre: 'Café Molido', descripcion: '250g café molido premium', precio: 3500 },
+    { nombre: 'Café en Grano', descripcion: 'Café en grano de altura', precio: 4000 },
+    { nombre: 'Café Orgánico', descripcion: 'Café sin pesticidas certificado', precio: 4500 },
+    { nombre: 'Taza de Cerámica', descripcion: 'Taza térmica de alta calidad', precio: 2500 },
+    { nombre: 'Filtro de Papel', descripcion: 'Paquete de 100 filtros para café', precio: 500 }
   ];
 
-  db.all('SELECT name FROM products', (err, rows) => {
+  db.all('SELECT nombre FROM productos', (err, rows) => {
     if (err) return;
-    const names = rows.map(r => r.name);
+    const names = rows.map(r => r.nombre);
     defaultProducts.forEach(p => {
-      if (!names.includes(p.name)) {
+      if (!names.includes(p.nombre)) {
         db.run(
-          'INSERT INTO products (name, description, price) VALUES (?, ?, ?)',
-          [p.name, p.description, p.price]
+          'INSERT INTO productos (nombre, descripcion, precio) VALUES (?, ?, ?)',
+          [p.nombre, p.descripcion, p.precio]
         );
       }
     });
   });
 
-  db.run(`CREATE TABLE IF NOT EXISTS cart (
+  db.run(`CREATE TABLE IF NOT EXISTS carrito (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    userId INTEGER,
-    productId INTEGER,
-    quantity INTEGER,
-    FOREIGN KEY(userId) REFERENCES users(id),
-    FOREIGN KEY(productId) REFERENCES products(id)
+    usuarioId INTEGER,
+    productoId INTEGER,
+    cantidad INTEGER,
+    FOREIGN KEY(usuarioId) REFERENCES usuarios(id),
+    FOREIGN KEY(productoId) REFERENCES productos(id)
   )`);
 
-  db.run(`CREATE TABLE IF NOT EXISTS orders (
+  db.run(`CREATE TABLE IF NOT EXISTS ordenes (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    orderId INTEGER,
-    userId INTEGER,
-    productId INTEGER,
-    productName TEXT,
-    productPrice REAL,
-    quantity INTEGER,
-    paymentMethod TEXT,
-    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY(userId) REFERENCES users(id),
-    FOREIGN KEY(productId) REFERENCES products(id)
+    ordenId INTEGER,
+    usuarioId INTEGER,
+    productoId INTEGER,
+    nombreProducto TEXT,
+    precioProducto REAL,
+    cantidad INTEGER,
+    metodoPago TEXT,
+    creadoEn DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(usuarioId) REFERENCES usuarios(id),
+    FOREIGN KEY(productoId) REFERENCES productos(id)
   )`);
 
-  db.run(`CREATE TABLE IF NOT EXISTS invoices (
+  db.run(`CREATE TABLE IF NOT EXISTS facturas (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    orderId INTEGER,
-    userId INTEGER,
-    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY(orderId) REFERENCES orders(orderId),
-    FOREIGN KEY(userId) REFERENCES users(id)
+    ordenId INTEGER,
+    usuarioId INTEGER,
+    creadoEn DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(ordenId) REFERENCES ordenes(ordenId),
+    FOREIGN KEY(usuarioId) REFERENCES usuarios(id)
   )`);
 
   // Ensure new columns exist for databases created with older versions
-  db.all('PRAGMA table_info(orders)', (err, columns) => {
+  db.all('PRAGMA table_info(ordenes)', (err, columns) => {
     if (err) return;
     const names = columns.map(c => c.name);
-    if (!names.includes('orderId')) {
-      db.run('ALTER TABLE orders ADD COLUMN orderId INTEGER');
+    if (!names.includes('ordenId')) {
+      db.run('ALTER TABLE ordenes ADD COLUMN ordenId INTEGER');
     }
-    if (!names.includes('paymentMethod')) {
-      db.run('ALTER TABLE orders ADD COLUMN paymentMethod TEXT');
+    if (!names.includes('metodoPago')) {
+      db.run('ALTER TABLE ordenes ADD COLUMN metodoPago TEXT');
     }
   });
 });

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -12,7 +12,7 @@ router.post('/register', async (req, res) => {
   try {
     const hash = await bcrypt.hash(contrasena, 10);
     db.run(
-      'INSERT INTO users (nombre, apellido, correo, contrasena) VALUES (?, ?, ?, ?)',
+      'INSERT INTO usuarios (nombre, apellido, correo, contrasena) VALUES (?, ?, ?, ?)',
       [nombre, apellido, correo, hash],
       function (err) {
         if (err) return res.status(500).json({ error: err.message });
@@ -26,7 +26,7 @@ router.post('/register', async (req, res) => {
 
 router.post('/login', (req, res) => {
   const { correo, contrasena } = req.body;
-  db.get('SELECT * FROM users WHERE correo = ?', [correo], async (err, row) => {
+  db.get('SELECT * FROM usuarios WHERE correo = ?', [correo], async (err, row) => {
     if (err) return res.status(500).json({ error: err.message });
     if (!row) return res.status(401).json({ error: 'Credenciales inválidas' });
     const match = await bcrypt.compare(contrasena, row.contrasena);

--- a/backend/routes/cart.js
+++ b/backend/routes/cart.js
@@ -4,34 +4,34 @@ const db = require('../models/db');
 const router = express.Router();
 
 router.post('/cart', (req, res) => {
-  const { userId, productId, quantity } = req.body;
+  const { usuarioId, productoId, cantidad } = req.body;
 
   // Check if the product already exists in the user's cart
   db.get(
-    'SELECT id, quantity FROM cart WHERE userId = ? AND productId = ?',
-    [userId, productId],
+    'SELECT id, cantidad FROM carrito WHERE usuarioId = ? AND productoId = ?',
+    [usuarioId, productoId],
     (err, row) => {
       if (err) return res.status(500).json({ error: err.message });
 
       if (row) {
         // If it exists, update the quantity
-        const newQty = row.quantity + quantity;
+        const newQty = row.cantidad + cantidad;
         db.run(
-          'UPDATE cart SET quantity = ? WHERE id = ?',
+          'UPDATE carrito SET cantidad = ? WHERE id = ?',
           [newQty, row.id],
           function (err) {
             if (err) return res.status(500).json({ error: err.message });
-            res.json({ id: row.id, quantity: newQty, updated: true });
+            res.json({ id: row.id, cantidad: newQty, updated: true });
           }
         );
       } else {
         // Otherwise insert a new record
         db.run(
-          'INSERT INTO cart (userId, productId, quantity) VALUES (?, ?, ?)',
-          [userId, productId, quantity],
+          'INSERT INTO carrito (usuarioId, productoId, cantidad) VALUES (?, ?, ?)',
+          [usuarioId, productoId, cantidad],
           function (err) {
             if (err) return res.status(500).json({ error: err.message });
-            res.json({ id: this.lastID, quantity, inserted: true });
+            res.json({ id: this.lastID, cantidad, inserted: true });
           }
         );
       }
@@ -40,13 +40,13 @@ router.post('/cart', (req, res) => {
 });
 
 router.get('/cart', (req, res) => {
-  const { userId } = req.query;
+  const { usuarioId } = req.query;
   db.all(`
-    SELECT c.id, p.name, p.price, c.quantity
-    FROM cart c
-    JOIN products p ON c.productId = p.id
-    WHERE c.userId = ?
-  `, [userId], (err, rows) => {
+    SELECT c.id, p.nombre, p.precio, c.cantidad
+    FROM carrito c
+    JOIN productos p ON c.productoId = p.id
+    WHERE c.usuarioId = ?
+  `, [usuarioId], (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });
@@ -54,7 +54,7 @@ router.get('/cart', (req, res) => {
 
 router.delete('/cart/:itemId', (req, res) => {
   const { itemId } = req.params;
-  db.run('DELETE FROM cart WHERE id = ?', [itemId], function(err) {
+  db.run('DELETE FROM carrito WHERE id = ?', [itemId], function(err) {
     if (err) return res.status(500).json({ error: err.message });
     res.json({ deleted: this.changes });
   });

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -4,7 +4,7 @@ const db = require('../models/db');
 const router = express.Router();
 
 router.get('/products', (req, res) => {
-  db.all('SELECT * FROM products', [], (err, rows) => {
+  db.all('SELECT * FROM productos', [], (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
   });

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,9 +9,9 @@ async function loadProducts() {
     container.innerHTML += `
       <div class="product-card">
         <img src="assets/product-default.jpg" alt="Producto">
-        <h3>${p.name}</h3>
-        <p>${p.description}</p>
-        <strong>$${p.price}</strong><br>
+    <h3>${p.nombre}</h3>
+        <p>${p.descripcion}</p>
+        <strong>$${p.precio}</strong><br>
         <button onclick="addToCart(${p.id})">Agregar al carrito</button>
       </div>
     `;
@@ -29,7 +29,7 @@ async function addToCart(productId) {
   await fetch("/api/cart", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ userId: user.id, productId, quantity: 1 }),
+    body: JSON.stringify({ usuarioId: user.id, productoId, cantidad: 1 }),
   });
 
   alert("Producto agregado al carrito");
@@ -40,7 +40,7 @@ async function viewCart() {
   const user = JSON.parse(localStorage.getItem("user"));
   if (!user) return;
 
-  const res = await fetch(`/api/cart?userId=${user.id}`);
+  const res = await fetch(`/api/cart?usuarioId=${user.id}`);
   const items = await res.json();
 
   const cartContainer = document.getElementById("cart");
@@ -48,11 +48,11 @@ async function viewCart() {
   cartContainer.innerHTML = "";
   let total = 0;
   items.forEach((item) => {
-    const subtotal = item.price * item.quantity;
+    const subtotal = item.precio * item.cantidad;
     total += subtotal;
     cartContainer.innerHTML += `
       <div class="cart-item">
-        ${item.name} x${item.quantity} - $${subtotal}
+        ${item.nombre} x${item.cantidad} - $${subtotal}
         <button onclick="removeFromCart(${item.id})">Eliminar</button>
       </div>
     `;
@@ -78,7 +78,7 @@ async function confirmPurchase(method) {
   const res = await fetch("/api/confirm", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ userId: user.id, method }),
+    body: JSON.stringify({ usuarioId: user.id, method }),
   });
 
   const data = await res.json();


### PR DESCRIPTION
## Summary
- traducir a español las tablas y campos de la base de datos
- actualizar rutas de la API para usar los nuevos nombres
- ajustar la lógica del cliente para consumir los campos en español

## Testing
- `node backend/server.js` *(fails: Cannot find module 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_6859ae8eaec0832e93eac19343cfcf7c