### PR TITLE
Improve duplicate email error

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -20,7 +20,17 @@ router.post('/register', async (req, res) => {
       'INSERT INTO usuarios (nombre, apellido, correo, contrasena) VALUES (?, ?, ?, ?)',
       [nombre, apellido, correo, hash],
       function (err) {
-        if (err) return res.status(500).json({ error: err.message });
+        if (err) {
+          if (
+            err.code === 'SQLITE_CONSTRAINT' &&
+            err.message.includes('usuarios.correo')
+          ) {
+            return res
+              .status(400)
+              .json({ error: 'Correo electrónico ya existente' });
+          }
+          return res.status(500).json({ error: err.message });
+        }
         res.json({ id: this.lastID, correo });
       }
     );


### PR DESCRIPTION
## Summary
- handle duplicate email registration errors and return a user-friendly message

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859c31befa8832eabe442474d0b7396