### PR TITLE
Add required field checks in registration

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -11,7 +11,13 @@ const router = express.Router();
 
 router.post('/register', async (req, res) => {
   const { nombre, apellido, correo, contrasena } = req.body;
-  if (!correo || !correo.includes('@')) {
+
+  // Validate required fields
+  if (!nombre || !apellido || !correo || !contrasena) {
+    return res.status(400).json({ error: 'Todos los campos son obligatorios' });
+  }
+
+  if (!correo.includes('@')) {
     return res.status(400).json({ error: 'Correo electrónico inválido' });
   }
   try {

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -11,10 +11,16 @@ function logout() {
 }
 
 async function register() {
-  const nombre = document.getElementById('regFirstName').value;
-  const apellido = document.getElementById('regLastName').value;
-  const correo = document.getElementById('regEmail').value;
-  const contrasena = document.getElementById('regPass').value;
+  const nombre = document.getElementById('regFirstName').value.trim();
+  const apellido = document.getElementById('regLastName').value.trim();
+  const correo = document.getElementById('regEmail').value.trim();
+  const contrasena = document.getElementById('regPass').value.trim();
+
+  if (!nombre || !apellido || !correo || !contrasena) {
+    alert('Todos los campos son obligatorios');
+    return;
+  }
+
   if (!correo.includes('@')) {
     alert('Correo electrónico inválido');
     return;

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -10,10 +10,10 @@
     <div class="auth-container">
       <img src="assets/logo.png" alt="Logo" class="logo">
       <h2>Registro</h2>
-      <input type="text" id="regFirstName" placeholder="Nombre">
-      <input type="text" id="regLastName" placeholder="Apellido">
-      <input type="email" id="regEmail" placeholder="Correo Electrónico">
-      <input type="password" id="regPass" placeholder="Contraseña">
+      <input type="text" id="regFirstName" placeholder="Nombre" required>
+      <input type="text" id="regLastName" placeholder="Apellido" required>
+      <input type="email" id="regEmail" placeholder="Correo Electrónico" required>
+      <input type="password" id="regPass" placeholder="Contraseña" required>
       <button onclick="register()">Registrarse</button>
       <p>¿Ya tienes cuenta? <a href="login.html">Inicia sesión</a></p>
       <p>Al registrarte confirmas que la información proporcionada es correcta.</p>


### PR DESCRIPTION
## Summary
- enforce required fields on server-side registration
- validate non-empty inputs on the frontend
- mark register fields as `required` in HTML

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859c58b5a04832e8e8f58e1b783010a