### PR TITLE
Add admin panel functionality

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,6 +8,12 @@ INSTRUCCIONES:
 3. Abrí http://localhost:3000/ en el navegador.
 4. Usá login o registro. Solo los usuarios logueados pueden agregar al carrito.
 
+ADMINISTRACIÓN:
+1. Creá un usuario normal y luego marcá su cuenta como administrador ejecutando:
+   sqlite3 backend/db.sqlite "UPDATE usuarios SET isAdmin=1 WHERE correo='tu@correo.com';"
+2. Ingresá a http://localhost:3000/admin/login para acceder al panel.
+3. Desde el dashboard podrás crear o borrar productos.
+
 La base de datos se encuentra en: backend/db.sqlite
 Puedes cambiar la ubicación de la base de datos y el puerto con las variables
 de entorno DB_PATH y PORT respectivamente.

--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -9,7 +9,8 @@ db.serialize(() => {
     nombre TEXT,
     apellido TEXT,
     correo TEXT UNIQUE,
-    contrasena TEXT
+    contrasena TEXT,
+    isAdmin INTEGER DEFAULT 0
   )`);
 
   // Ensure new columns exist for older databases
@@ -30,6 +31,9 @@ db.serialize(() => {
     }
     if (!names.includes('contrasena')) {
       db.run('ALTER TABLE usuarios ADD COLUMN contrasena TEXT');
+    }
+    if (!names.includes('isAdmin')) {
+      db.run('ALTER TABLE usuarios ADD COLUMN isAdmin INTEGER DEFAULT 0');
     }
   });
 

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const db = require('../models/db');
+const router = express.Router();
+
+function checkAdmin(req, res, next) {
+  const id = req.header('x-user-id');
+  if (!id) return res.status(401).json({ error: 'Falta ID de usuario' });
+  db.get('SELECT isAdmin FROM usuarios WHERE id = ?', [id], (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row || row.isAdmin !== 1)
+      return res.status(403).json({ error: 'Acceso denegado' });
+    next();
+  });
+}
+
+router.use(checkAdmin);
+
+router.get('/users', (req, res) => {
+  db.all('SELECT id, nombre, apellido, correo, isAdmin FROM usuarios', (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+router.get('/orders', (req, res) => {
+  const q = `SELECT o.ordenId, o.usuarioId, o.nombreProducto, o.precioProducto,
+                    o.cantidad, o.metodoPago, o.creadoEn,
+                    u.nombre, u.apellido
+             FROM ordenes o
+             LEFT JOIN usuarios u ON o.usuarioId = u.id
+             ORDER BY o.ordenId DESC`;
+  db.all(q, [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+router.post('/products', (req, res) => {
+  const { nombre, descripcion, precio } = req.body;
+  db.run(
+    'INSERT INTO productos (nombre, descripcion, precio) VALUES (?, ?, ?)',
+    [nombre, descripcion, precio],
+    function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ id: this.lastID });
+    }
+  );
+});
+
+router.put('/products/:id', (req, res) => {
+  const { nombre, descripcion, precio } = req.body;
+  db.run(
+    'UPDATE productos SET nombre = ?, descripcion = ?, precio = ? WHERE id = ?',
+    [nombre, descripcion, precio, req.params.id],
+    function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ updated: this.changes });
+    }
+  );
+});
+
+router.delete('/products/:id', (req, res) => {
+  db.run('DELETE FROM productos WHERE id = ?', [req.params.id], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ deleted: this.changes });
+  });
+});
+
+module.exports = router;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -52,7 +52,13 @@ router.post('/login', (req, res) => {
     if (!row) return res.status(401).json({ error: 'Credenciales inválidas' });
     const match = hashPassword(contrasena) === row.contrasena;
     if (!match) return res.status(401).json({ error: 'Credenciales inválidas' });
-    res.json({ id: row.id, correo: row.correo, nombre: row.nombre, apellido: row.apellido });
+    res.json({
+      id: row.id,
+      correo: row.correo,
+      nombre: row.nombre,
+      apellido: row.apellido,
+      isAdmin: row.isAdmin
+    });
   });
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ const authRoutes = require('./routes/auth');
 const confirmRoutes = require('./routes/confirm');
 const productRoutes = require('./routes/products');
 const cartRoutes = require('./routes/cart');
+const adminRoutes = require('./routes/admin');
 
 const app = express();
 app.use(cors());
@@ -16,11 +17,20 @@ app.get('/', (req, res) =>
   res.sendFile(path.join(__dirname, '../frontend/landing.html'))
 );
 app.use(express.static(path.join(__dirname, '../frontend')));
+app.use('/admin', express.static(path.join(__dirname, '../frontend/admin')));
+
+app.get('/admin', (req, res) =>
+  res.sendFile(path.join(__dirname, '../frontend/admin/dashboard.html'))
+);
+app.get('/admin/login', (req, res) =>
+  res.sendFile(path.join(__dirname, '../frontend/admin/login.html'))
+);
 
 app.use('/api', authRoutes);
 app.use('/api', productRoutes);
 app.use('/api', cartRoutes);
 app.use('/api', confirmRoutes);
+app.use('/admin/api', adminRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/frontend/admin/admin.js
+++ b/frontend/admin/admin.js
@@ -1,0 +1,70 @@
+function adminLogin() {
+  const correo = document.getElementById('logEmail').value;
+  const contrasena = document.getElementById('logPass').value;
+  fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ correo, contrasena })
+  })
+    .then(r => r.json().then(d => ({ ok: r.ok, data: d })))
+    .then(({ ok, data }) => {
+      if (!ok) return alert(data.error || 'Error');
+      if (!data.isAdmin) return alert('No eres administrador');
+      localStorage.setItem('user', JSON.stringify(data));
+      window.location.href = 'dashboard.html';
+    });
+}
+
+function checkAdmin() {
+  const user = JSON.parse(localStorage.getItem('user'));
+  if (!user || !user.isAdmin) {
+    window.location.href = 'login.html';
+    return;
+  }
+  loadAdminProducts();
+}
+
+function logout() {
+  localStorage.removeItem('user');
+  window.location.href = 'login.html';
+}
+
+function loadAdminProducts() {
+  fetch('/api/products')
+    .then(r => r.json())
+    .then(data => {
+      const container = document.getElementById('products');
+      container.innerHTML = '';
+      data.forEach(p => {
+        container.innerHTML += `<div>${p.nombre} - $${p.precio} <button onclick="deleteProduct(${p.id})">Eliminar</button></div>`;
+      });
+    });
+}
+
+function deleteProduct(id) {
+  const user = JSON.parse(localStorage.getItem('user'));
+  fetch('/admin/api/products/' + id, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', 'x-user-id': user.id }
+  }).then(() => loadAdminProducts());
+}
+
+function createProduct() {
+  const user = JSON.parse(localStorage.getItem('user'));
+  const nombre = document.getElementById('newName').value;
+  const descripcion = document.getElementById('newDesc').value;
+  const precio = parseFloat(document.getElementById('newPrice').value);
+  fetch('/admin/api/products', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-user-id': user.id
+    },
+    body: JSON.stringify({ nombre, descripcion, precio })
+  }).then(() => {
+    document.getElementById('newName').value = '';
+    document.getElementById('newDesc').value = '';
+    document.getElementById('newPrice').value = '';
+    loadAdminProducts();
+  });
+}

--- a/frontend/admin/dashboard.html
+++ b/frontend/admin/dashboard.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Dashboard</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body onload="checkAdmin()">
+  <div class="auth-container">
+    <h2>Panel de Administración</h2>
+    <button onclick="logout()" class="logout-btn">Cerrar Sesión</button>
+    <h3>Productos</h3>
+    <div id="productForm">
+      <input id="newName" placeholder="Nombre">
+      <input id="newDesc" placeholder="Descripción">
+      <input id="newPrice" type="number" placeholder="Precio">
+      <button onclick="createProduct()">Agregar</button>
+    </div>
+    <div id="products"></div>
+  </div>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/frontend/admin/login.html
+++ b/frontend/admin/login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin Login</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+<body class="auth-body">
+  <div class="auth-container">
+    <img src="../assets/logo.png" alt="Logo" class="logo">
+    <h2>Acceso Administrador</h2>
+    <input type="email" id="logEmail" placeholder="Correo Electrónico">
+    <input type="password" id="logPass" placeholder="Contraseña">
+    <button onclick="adminLogin()">Ingresar</button>
+  </div>
+  <script src="admin.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend user model with `isAdmin` flag
- return `isAdmin` on login
- create admin API routes and mount them
- serve admin dashboard and login pages
- add minimal frontend admin panel
- document how to enable admin users

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b39fbe74c832ea84d2f7f7ad66af8