### PR TITLE
Implement cobranzas CRUD endpoints

### DIFF
--- a/backend/routes/cobranzas.js
+++ b/backend/routes/cobranzas.js
@@ -1,0 +1,93 @@
+const express = require('express');
+const db = require('../models/db');
+const router = express.Router();
+
+// Crear una nueva cobranza / orden
+router.post('/cobranzas', (req, res) => {
+  const { usuarioId, items, metodoPago } = req.body;
+  if (!usuarioId || !Array.isArray(items) || !items.length) {
+    return res.status(400).json({ error: 'Datos incompletos' });
+  }
+  db.get('SELECT COALESCE(MAX(ordenId), 0) as maxId FROM ordenes', (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    const orderId = (row ? row.maxId : 0) + 1;
+    const stmt = db.prepare(
+      'INSERT INTO ordenes (ordenId, usuarioId, productoId, nombreProducto, precioProducto, cantidad, metodoPago) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    );
+    let pending = items.length;
+    items.forEach(it => {
+      db.get('SELECT nombre, precio FROM productos WHERE id = ?', [it.productoId], (er2, prod) => {
+        if (er2) {
+          pending = -1;
+          return res.status(500).json({ error: er2.message });
+        }
+        if (!prod) {
+          pending = -1;
+          return res.status(400).json({ error: 'Producto no encontrado' });
+        }
+        stmt.run(orderId, usuarioId, it.productoId, prod.nombre, prod.precio, it.cantidad, metodoPago, function(er3) {
+          if (er3) {
+            pending = -1;
+            return res.status(500).json({ error: er3.message });
+          }
+          pending--;
+          if (pending === 0) {
+            stmt.finalize(e => {
+              if (e) return res.status(500).json({ error: e.message });
+              res.json({ orderId });
+            });
+          }
+        });
+      });
+    });
+  });
+});
+
+// Obtener listado de cobranzas
+router.get('/cobranzas', (req, res) => {
+  const q = `SELECT o.ordenId, o.usuarioId, o.nombreProducto, o.precioProducto,
+                    o.cantidad, o.metodoPago, o.creadoEn,
+                    u.nombre, u.apellido
+             FROM ordenes o
+             LEFT JOIN usuarios u ON o.usuarioId = u.id
+             ORDER BY o.ordenId DESC`;
+  db.all(q, [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+// Consulta de una cobranza por ID
+router.get('/cobranzas/:ordenId', (req, res) => {
+  const { ordenId } = req.params;
+  const q = `SELECT * FROM ordenes WHERE ordenId = ?`;
+  db.all(q, [ordenId], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!rows.length) return res.status(404).json({ error: 'Cobranza no encontrada' });
+    res.json(rows);
+  });
+});
+
+// Modificar metodo de pago de una cobranza
+router.put('/cobranzas/:ordenId', (req, res) => {
+  const { metodoPago } = req.body;
+  if (!metodoPago) return res.status(400).json({ error: 'Metodo de pago requerido' });
+  db.run('UPDATE ordenes SET metodoPago = ? WHERE ordenId = ?', [metodoPago, req.params.ordenId], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ updated: this.changes });
+  });
+});
+
+// Eliminar una cobranza
+router.delete('/cobranzas/:ordenId', (req, res) => {
+  const { ordenId } = req.params;
+  db.serialize(() => {
+    db.run('DELETE FROM facturas WHERE ordenId = ?', [ordenId]);
+    db.run('DELETE FROM ordenes WHERE ordenId = ?', [ordenId], function(err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ deleted: this.changes });
+    });
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,7 @@ const confirmRoutes = require('./routes/confirm');
 const productRoutes = require('./routes/products');
 const cartRoutes = require('./routes/cart');
 const adminRoutes = require('./routes/admin');
+const cobranzaRoutes = require('./routes/cobranzas');
 
 const app = express();
 app.use(cors());
@@ -30,6 +31,7 @@ app.use('/api', authRoutes);
 app.use('/api', productRoutes);
 app.use('/api', cartRoutes);
 app.use('/api', confirmRoutes);
+app.use('/api', cobranzaRoutes);
 app.use('/admin/api', adminRoutes);
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add new `cobranzas` route to perform CRUD operations on `ordenes`
- mount cobranzas endpoints in backend server

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./server')"` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_685b63b23114832eac4de668350acf73