### PR TITLE
Enable full order item edits

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -28,7 +28,7 @@ router.get('/users', (req, res) => {
 });
 
 router.get('/orders', (req, res) => {
-  const q = `SELECT o.ordenId, o.usuarioId, o.nombreProducto, o.precioProducto,
+  const q = `SELECT o.id, o.ordenId, o.usuarioId, o.productoId, o.nombreProducto, o.precioProducto,
                     o.cantidad, o.metodoPago, o.creadoEn,
                     u.nombre, u.apellido
              FROM ordenes o


### PR DESCRIPTION
## Summary
- expose item id and product id in admin orders API
- validate payment method list for cobranzas
- allow updating/deleting individual order items in API
- add admin UI features to edit/delete products in an order

## Testing
- `node backend/tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_685c6213983c832ebff0af4ebbf7140a