### PR TITLE
Change supplier contact field to email

### DIFF
--- a/backend/models/db.js
+++ b/backend/models/db.js
@@ -101,9 +101,18 @@ db.serialize(() => {
   db.run(`CREATE TABLE IF NOT EXISTS proveedores (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     nombre TEXT,
-    contacto TEXT,
+    correo TEXT,
     telefono TEXT
   )`);
+
+  db.all('PRAGMA table_info(proveedores)', (err, columns) => {
+    if (err) return;
+    const names = columns.map(c => c.name);
+    if (!names.includes('correo')) {
+      db.run('ALTER TABLE proveedores ADD COLUMN correo TEXT');
+      db.run('UPDATE proveedores SET correo = contacto WHERE correo IS NULL');
+    }
+  });
 
   // Ensure new columns exist for databases created with older versions
   db.all('PRAGMA table_info(ordenes)', (err, columns) => {

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -171,7 +171,7 @@ router.get('/suppliers', (req, res) => {
   const search = req.query.search || '';
   const like = `%${search}%`;
   const q =
-    'SELECT * FROM proveedores WHERE nombre LIKE ? OR contacto LIKE ? OR telefono LIKE ?';
+    'SELECT * FROM proveedores WHERE nombre LIKE ? OR correo LIKE ? OR telefono LIKE ?';
   db.all(q, [like, like, like], (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json(rows);
@@ -187,10 +187,16 @@ router.get('/suppliers/:id', (req, res) => {
 });
 
 router.post('/suppliers', (req, res) => {
-  const { nombre, contacto, telefono } = req.body;
+  const { nombre, correo, telefono } = req.body;
+  if (!nombre || !correo) {
+    return res.status(400).json({ error: 'Nombre y correo son obligatorios' });
+  }
+  if (!correo.includes('@')) {
+    return res.status(400).json({ error: 'Correo electrónico inválido' });
+  }
   db.run(
-    'INSERT INTO proveedores (nombre, contacto, telefono) VALUES (?, ?, ?)',
-    [nombre, contacto, telefono],
+    'INSERT INTO proveedores (nombre, correo, telefono) VALUES (?, ?, ?)',
+    [nombre, correo, telefono],
     function (err) {
       if (err) return res.status(500).json({ error: err.message });
       res.json({ id: this.lastID });
@@ -199,16 +205,19 @@ router.post('/suppliers', (req, res) => {
 });
 
 router.put('/suppliers/:id', (req, res) => {
-  const { nombre, contacto, telefono } = req.body;
+  const { nombre, correo, telefono } = req.body;
   const fields = [];
   const params = [];
   if (nombre !== undefined) {
     fields.push('nombre = ?');
     params.push(nombre);
   }
-  if (contacto !== undefined) {
-    fields.push('contacto = ?');
-    params.push(contacto);
+  if (correo !== undefined) {
+    if (!correo.includes('@')) {
+      return res.status(400).json({ error: 'Correo electrónico inválido' });
+    }
+    fields.push('correo = ?');
+    params.push(correo);
   }
   if (telefono !== undefined) {
     fields.push('telefono = ?');

--- a/frontend/admin/admin.js
+++ b/frontend/admin/admin.js
@@ -317,7 +317,7 @@ function loadAdminSuppliers() {
       container.innerHTML = '';
       data.forEach(s => {
         container.innerHTML +=
-          `<div>${s.nombre} - ${s.contacto || ''} - ${s.telefono || ''} ` +
+          `<div>${s.nombre} - ${s.correo || ''} - ${s.telefono || ''} ` +
           `<button onclick="editSupplier(${s.id})">Editar</button> ` +
           `<button onclick="deleteSupplier(${s.id})">Eliminar</button></div>`;
       });
@@ -336,7 +336,7 @@ function editSupplier(id) {
   const s = adminSuppliers.find(sp => sp.id === id);
   if (!s) return;
   document.getElementById('supplierName').value = s.nombre;
-  document.getElementById('supplierContact').value = s.contacto || '';
+  document.getElementById('supplierEmail').value = s.correo || '';
   document.getElementById('supplierPhone').value = s.telefono || '';
   document.getElementById('saveSupplierBtn').textContent = 'Guardar';
   supplierEditId = id;
@@ -345,7 +345,7 @@ function editSupplier(id) {
 function createSupplier() {
   const user = JSON.parse(localStorage.getItem('user'));
   const nombre = document.getElementById('supplierName').value;
-  const contacto = document.getElementById('supplierContact').value;
+  const correo = document.getElementById('supplierEmail').value;
   const telefono = document.getElementById('supplierPhone').value;
   const url = supplierEditId
     ? '/admin/api/suppliers/' + supplierEditId
@@ -354,10 +354,10 @@ function createSupplier() {
   fetch(url, {
     method,
     headers: { 'Content-Type': 'application/json', 'x-user-id': user.id },
-    body: JSON.stringify({ nombre, contacto, telefono })
+    body: JSON.stringify({ nombre, correo, telefono })
   }).then(() => {
     document.getElementById('supplierName').value = '';
-    document.getElementById('supplierContact').value = '';
+    document.getElementById('supplierEmail').value = '';
     document.getElementById('supplierPhone').value = '';
     document.getElementById('saveSupplierBtn').textContent = 'Agregar';
     supplierEditId = null;

--- a/frontend/admin/dashboard.html
+++ b/frontend/admin/dashboard.html
@@ -60,8 +60,8 @@
         <h3>Proveedores</h3>
         <input id="searchSuppliers" placeholder="Buscar..." oninput="loadAdminSuppliers()">
         <div id="supplierForm">
-          <input id="supplierName" placeholder="Nombre">
-          <input id="supplierContact" placeholder="Contacto">
+          <input id="supplierName" placeholder="Nombre" required>
+          <input id="supplierEmail" type="email" placeholder="Correo Electrónico" required>
           <input id="supplierPhone" placeholder="Teléfono">
           <button id="saveSupplierBtn" onclick="createSupplier()">Agregar</button>
         </div>


### PR DESCRIPTION
## Summary
- rename supplier `contacto` field to `correo`
- require and validate email on supplier POST/PUT
- adjust DB schema to include `correo`
- update admin dashboard and scripts for `Correo Electrónico`

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685c8ecead5c832ebdc1e26a78c88636