### PR TITLE
Add supplier form validations

### DIFF
--- a/frontend/admin/admin.js
+++ b/frontend/admin/admin.js
@@ -347,6 +347,15 @@ function createSupplier() {
   const nombre = document.getElementById('supplierName').value;
   const correo = document.getElementById('supplierEmail').value;
   const telefono = document.getElementById('supplierPhone').value;
+  if (!nombre || !correo) {
+    alert('Nombre y correo electrónico son obligatorios');
+    return;
+  }
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(correo)) {
+    alert('Formato de correo electrónico inválido');
+    return;
+  }
   const url = supplierEditId
     ? '/admin/api/suppliers/' + supplierEditId
     : '/admin/api/suppliers';


### PR DESCRIPTION
## Summary
- notify admin if supplier name or email are missing
- alert if supplier email format is invalid

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685c92f64c0c832e8fe716f28967566f