### PR TITLE
Update purchase orders UI and stock management

### DIFF
--- a/backend/routes/confirm.js
+++ b/backend/routes/confirm.js
@@ -79,6 +79,7 @@ router.post('/confirm', (req, res) => {
       );
       items.forEach(i => {
         stmt.run(orderId, usuarioId, i.productoId, i.nombre, i.precio, i.cantidad, method);
+        db.run('UPDATE productos SET stock = stock - ? WHERE id = ?', [i.cantidad, i.productoId]);
       });
       stmt.finalize(err => {
         if (err) return res.status(500).json({ error: err.message });

--- a/frontend/admin/admin.js
+++ b/frontend/admin/admin.js
@@ -409,7 +409,7 @@ function renderPurchases() {
         `<div>Orden ${p.ordenId} - ${p.proveedorNombre || ''} (${p.proveedorId}) - ` +
         `${p.nombreProducto} x${p.cantidad} - $${p.precioProducto} - ${p.creadoEn} ` +
         `<button onclick="editPurchaseItem(${p.id})">Modificar</button> ` +
-        `<button onclick="deletePurchaseItem(${p.id})">Eliminar Producto</button> ` +
+        `<button onclick="viewPurchase(${p.ordenId})">Visualizar</button> ` +
         `<button onclick="deletePurchaseOrder(${p.ordenId})">Eliminar Orden</button></div>`;
     });
 }
@@ -457,6 +457,20 @@ function editPurchaseItem(id) {
         headers: { 'Content-Type': 'application/json', 'x-user-id': user.id },
         body: JSON.stringify({ productoId: prodId, cantidad, precioProducto: precio })
       }).then(() => loadAdminPurchases());
+    });
+}
+
+function viewPurchase(id) {
+  const user = JSON.parse(localStorage.getItem('user'));
+  fetch('/admin/api/purchase-orders/' + id, { headers: { 'x-user-id': user.id } })
+    .then(r => r.json())
+    .then(items => {
+      if (!items.length) return;
+      let msg = `Orden ${id} - ${items[0].proveedorNombre || ''}\n`;
+      items.forEach(it => {
+        msg += `${it.nombreProducto} x${it.cantidad} - $${it.precioProducto}\n`;
+      });
+      alert(msg);
     });
 }
 


### PR DESCRIPTION
## Summary
- remove 'Eliminar Producto' action from purchase orders list
- add a 'Visualizar' button for purchase orders
- deduct product stock when confirming a user purchase

## Testing
- `node backend/tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_685cb47c1494832e8d3330f0007a6c05