### PR TITLE
Fix purchase order modal close button

### DIFF
--- a/frontend/admin/admin.js
+++ b/frontend/admin/admin.js
@@ -508,7 +508,8 @@ function deletePurchaseOrder(id) {
 }
 
 function openModal(html) {
-  document.getElementById('modalContent').innerHTML = html;
+  document.getElementById('modalContent').innerHTML = html +
+    '<button onclick="closeModal()">Cerrar</button>';
   document.getElementById('modal').style.display = 'flex';
 }
 


### PR DESCRIPTION
## Summary
- ensure purchase order modal includes a `Cerrar` button when opened

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685da1645328832e959af487f3d41745