### PR TITLE
Fix image upload from products module

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -11,7 +11,8 @@ const cobranzaRoutes = require('./routes/cobranzas');
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+// Allow larger JSON payloads to support base64-encoded images
+app.use(express.json({ limit: '10mb' }));
 // Sirve la página de inicio antes de la carpeta estática para evitar que index.html
 // intercepte la ruta raíz
 app.get('/', (req, res) =>


### PR DESCRIPTION
## Summary
- bump JSON body limit to accept base64 encoded product images

## Testing
- `node backend/tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_685dcd1ce1d0832e9b10e5dd0bf95fec