### PR TITLE
Fix image path

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4,7 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const db = require('../models/db');
 
-const uploadDir = path.join(__dirname, '../frontend/uploads');
+// Almacenamos las imágenes en la carpeta pública de uploads
+const uploadDir = path.join(__dirname, '../../frontend/uploads');
 if (!fs.existsSync(uploadDir)) {
   fs.mkdirSync(uploadDir, { recursive: true });
 }


### PR DESCRIPTION
## Summary
- correct uploads directory path so product images are saved under `frontend/uploads`

## Testing
- `npm test --silent` *(fails: npm tries to reach the network)*

------
https://chatgpt.com/codex/tasks/task_e_685dd141bb6c832ea24b598c532a1a8d